### PR TITLE
Add the ability to run exec-out commands

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/kpcyrd/forensic-adb"
 edition = "2021"
 
 [dependencies]
+bstr = "1.9.1"
 log = { version = "0.4", features = ["std"] }
 once_cell = "1.4.0"
 regex = { version = "1", default-features = false, features = ["perf", "std"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -442,7 +442,7 @@ impl Device {
         command: &str,
         has_output: bool,
         has_length: bool,
-    ) -> Result<String> {
+    ) -> Result<Vec<u8>> {
         let mut stream = self.host.connect().await?;
 
         let switch_command = format!("host:transport:{}", self.serial);
@@ -459,8 +459,22 @@ impl Device {
             .write_all(encode_message(command)?.as_bytes())
             .await?;
         let bytes = read_response(&mut stream, has_output, has_length).await?;
+        trace!("execute_host_command: << {:?}", bstr::BStr::new(&bytes));
+
+        Ok(bytes)
+    }
+
+    pub async fn execute_host_command_to_string(
+        &self,
+        command: &str,
+        has_output: bool,
+        has_length: bool,
+    ) -> Result<String> {
+        let bytes = self
+            .execute_host_command(command, has_output, has_length)
+            .await?;
+
         let response = std::str::from_utf8(&bytes)?;
-        trace!("execute_host_command: << {:?}", response);
 
         // Unify new lines by removing possible carriage returns
         Ok(response.replace("\r\n", "\n"))
@@ -527,7 +541,7 @@ impl Device {
         // We don't want to duplicate su invocations.
         if shell_command.starts_with("su") {
             return self
-                .execute_host_command(&format!("shell:{}", shell_command), true, false)
+                .execute_host_command_to_string(&format!("shell:{}", shell_command), true, false)
                 .await;
         }
 
@@ -543,7 +557,7 @@ impl Device {
 
             if has_outer_quotes {
                 return self
-                    .execute_host_command(
+                    .execute_host_command_to_string(
                         &format!("shell:run-as {} {}", run_as_package, shell_command),
                         true,
                         false,
@@ -554,7 +568,7 @@ impl Device {
             if SYNC_REGEX.is_match(shell_command) {
                 let arg: &str = &shell_command.replace('\'', "'\"'\"'")[..];
                 return self
-                    .execute_host_command(
+                    .execute_host_command_to_string(
                         &format!("shell:run-as {} {}", run_as_package, arg),
                         true,
                         false,
@@ -563,7 +577,7 @@ impl Device {
             }
 
             return self
-                .execute_host_command(
+                .execute_host_command_to_string(
                     &format!("shell:run-as {} \"{}\"", run_as_package, shell_command),
                     true,
                     false,
@@ -571,7 +585,7 @@ impl Device {
                 .await;
         }
 
-        self.execute_host_command(&format!("shell:{}", shell_command), true, false)
+        self.execute_host_command_to_string(&format!("shell:{}", shell_command), true, false)
             .await
     }
 
@@ -640,7 +654,9 @@ impl Device {
 
     pub async fn reverse_port(&self, remote: u16, local: u16) -> Result<u16> {
         let command = format!("reverse:forward:tcp:{};tcp:{}", remote, local);
-        let response = self.execute_host_command(&command, true, false).await?;
+        let response = self
+            .execute_host_command_to_string(&command, true, false)
+            .await?;
 
         if remote == 0 {
             Ok(response.parse::<u16>()?)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -497,13 +497,13 @@ impl Device {
     }
 
     pub async fn execute_host_exec_out_command(&self, shell_command: &str) -> Result<Vec<u8>> {
-        return self
+        self
             .execute_host_command(
                 &format!("exec:{}", shell_command),
                 true,
                 false,
             )
-            .await;
+            .await
     }
 
     pub async fn execute_host_shell_command_as(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -497,12 +497,7 @@ impl Device {
     }
 
     pub async fn execute_host_exec_out_command(&self, shell_command: &str) -> Result<Vec<u8>> {
-        self
-            .execute_host_command(
-                &format!("exec:{}", shell_command),
-                true,
-                false,
-            )
+        self.execute_host_command(&format!("exec:{}", shell_command), true, false)
             .await
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -480,33 +480,6 @@ impl Device {
         Ok(response.replace("\r\n", "\n"))
     }
 
-    pub async fn execute_host_command_raw(
-        &self,
-        command: &str,
-        has_output: bool,
-        has_length: bool,
-    ) -> Result<Vec<u8>> {
-        let mut stream = self.host.connect().await?;
-
-        let switch_command = format!("host:transport:{}", self.serial);
-        trace!("execute_host_command_raw: >> {:?}", &switch_command);
-        stream
-            .write_all(encode_message(&switch_command)?.as_bytes())
-            .await?;
-        let _bytes = read_response(&mut stream, false, false).await?;
-        trace!("execute_host_command_raw: << {:?}", _bytes);
-
-        trace!("execute_host_command_raw: >> {:?}", &command);
-        stream
-            .write_all(encode_message(command)?.as_bytes())
-            .await?;
-        let bytes = read_response(&mut stream, has_output, has_length).await?;
-        trace!("execute_host_command_raw: << {:?}", bytes);
-
-        Ok(bytes)
-    }
-
-
     pub fn enable_run_as_for_path(&self, path: &UnixPath) -> bool {
         match &self.run_as_package {
             Some(package) => {
@@ -525,7 +498,7 @@ impl Device {
 
     pub async fn execute_host_exec_out_command(&self, shell_command: &str) -> Result<Vec<u8>> {
         return self
-            .execute_host_command_raw(
+            .execute_host_command(
                 &format!("exec:{}", shell_command),
                 true,
                 false,


### PR DESCRIPTION
New function that is essentially the equivalent of running "adb exec-out" instead of "adb shell" and returns raw bytes instead of a utf-8 decoded string. Use I know of is getting a screenshot IE: 

```
    // Capture an image of the device's screen
    async fn capture_image(&mut self) -> Result<RgbaImage> {
        let res = self.device.execute_host_exec_out_command("screencap -p").await?;
        let img = image::load_from_memory(&res)?;
        Ok(img.as_rgba8().unwrap().clone())
    }
```

Very loosely referenced from the adb_shell python library: 

https://github.com/JeffLIrion/adb_shell

plus the existing code obviously. 

Also for some reason I've added Clone derivation to the Device struct, which probably shouldn't be lumped in the same commit but afaik shouldn't do any harm.