### PR TITLE
Make execute_host_command return binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/kpcyrd/forensic-adb"
 edition = "2021"
 
 [dependencies]
+bstr = "1.9.1"
 log = { version = "0.4", features = ["std"] }
 once_cell = "1.4.0"
 regex = { version = "1", default-features = false, features = ["perf", "std"] }


### PR DESCRIPTION
This provides access to the response as `Vec<u8>` for #1 without duplicating the `execute_host_command` function.

Consumers of this library likely want the data with no post-processing anyway. The old interface is still available as `execute_host_command_to_string` but I'm thinking about removing some of the functions that build on this.